### PR TITLE
Added spaces before init.

### DIFF
--- a/File Templates/Singleton/Objective-C Singleton class.xctemplate/___FILEBASENAME___.m
+++ b/File Templates/Singleton/Objective-C Singleton class.xctemplate/___FILEBASENAME___.m
@@ -21,7 +21,7 @@ static bool isFirstAccess = YES;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         isFirstAccess = NO;
-        SINGLETON = [[super allocWithZone:NULL]init];    
+        SINGLETON = [[super allocWithZone:NULL] init];    
     });
     
     return SINGLETON;
@@ -46,12 +46,12 @@ static bool isFirstAccess = YES;
 
 - (id)copy
 {
-    return [[___FILEBASENAMEASIDENTIFIER___ alloc]init];
+    return [[___FILEBASENAMEASIDENTIFIER___ alloc] init];
 }
 
 - (id)mutableCopy
 {
-    return [[___FILEBASENAMEASIDENTIFIER___ alloc]init];
+    return [[___FILEBASENAMEASIDENTIFIER___ alloc] init];
 }
 
 - (id) init


### PR DESCRIPTION
Chained method calls in Objective-C are usually separated with spaces. This change is minor but will make the classes created from it adhere to a more usual code style in this regard.
